### PR TITLE
Rate Limiting for Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ WantedBy=multi-user.target
 - [ ] **Use ChatGPT for Notifications:** Integrate ChatGPT to generate notification messages, potentially as a third button option.
 - [ ] **Text Field for Context:** Add a text field for each status, allowing visitors to provide context for ChatGPT to create personalized notification messages.
 - [ ] **Set Up CI with GitHub Actions:** Implement continuous integration (CI) using GitHub Actions to automate testing and deployment.
-- [ ] **Rate Limiting for Notifications:** Implement rate limiting to control the frequency of chat notifications and reduce the risk of abuse. This can involve setting limits on the number of notifications sent per user or IP address within a specific time frame.
+- [x] **Rate Limiting for Notifications:** Implement rate limiting to control the frequency of chat notifications and reduce the risk of abuse. This can involve setting limits on the number of notifications sent per user or IP address within a specific time frame.
 
 # Contribution guide
 Your contributions are greatly appreciated. Please follow the guidelines below to ensure a smooth and efficient collaboration.

--- a/config/app.rb
+++ b/config/app.rb
@@ -36,7 +36,7 @@ class OfficeApp
       if current_time - last_request_time < RATE_LIMIT_PERIOD
         remaining_time = (RATE_LIMIT_PERIOD - (current_time - last_request_time)) / 60.0
         message = "Rate limit exceeded. Please try again in #{remaining_time.ceil} minutes."
-        raise AccessDenied, "Rate limit exceeded. Please try again in #{remaining_time.ceil} minutes."
+        raise AccessDenied, "🛑 Rate limit exceeded.<br />Please try again in #{remaining_time.ceil} minutes"
       else
         RATE_LIMIT_CACHE[key] = current_time
       end

--- a/router.rb
+++ b/router.rb
@@ -25,12 +25,12 @@ class RequestRouter
 
     when '/coffee/ready'
       @app.apply_rate_limit!('coffee_ready')
-      status_code, status_message = @app.post_to_google_chat("Ready message triggered! (via Ruby script)")
+      status_code, status_message = @app.post_to_google_chat("القهوة جاهزة ☕")
       [302, { 'location' => '/coffee?status=ready' }, []]
 
     when '/coffee/finish'
       @app.apply_rate_limit!('coffee_finish')
-      status_code, status_message = @app.post_to_google_chat("Finish message triggered! (via Ruby script)")
+      status_code, status_message = @app.post_to_google_chat("خلصت القهوة 🚫")
       [302, { 'location' => '/coffee?status=finish' }, []]
 
     else

--- a/router.rb
+++ b/router.rb
@@ -1,11 +1,15 @@
 # router.rb
 
 class RequestRouter
+  attr_reader :current_request
+
   def initialize(app)
     @app = app
   end
 
   def handle_request(request)
+    @current_request = request # Expose current request for IP address retrieval
+
     case request.path
 
     when '/coffee'
@@ -22,13 +26,22 @@ class RequestRouter
       @app.serve_html('coffee/index.html', message: message)
 
     when '/coffee/ready'
-      status_code, status_message = @app.post_to_google_chat("Ready message triggered! (via Ruby script)")
-      [302, { 'location' => '/coffee?status=ready' }, []]
+      status_code, message = @app.can_access?('coffee_ready')
+      if status_code == 200
+        status_code, status_message = @app.post_to_google_chat("Ready message triggered! (via Ruby script)")
+        [302, { 'location' => '/coffee?status=ready' }, []]
+      else
+        @app.serve_html('coffee/index.html', message: message)
+      end
 
     when '/coffee/finish'
-      status_code, status_message = @app.post_to_google_chat("Finish message triggered! (via Ruby script)")
-      [302, { 'location' => '/coffee?status=finish' }, []]
-
+      status_code, message = @app.can_access?('coffee_finish')
+      if status_code == 200
+        status_code, status_message = @app.post_to_google_chat("Finish message triggered! (via Ruby script)")
+        [302, { 'location' => '/coffee?status=finish' }, []]
+      else
+        @app.serve_html('coffee/index.html', message: message)
+      end
     else
       @app.serve_html('404.html', 404)
     end

--- a/router.rb
+++ b/router.rb
@@ -11,7 +11,6 @@ class RequestRouter
     @current_request = request # Expose current request for IP address retrieval
 
     case request.path
-
     when '/coffee'
       status_param = request.params['status']
       case status_param
@@ -22,28 +21,21 @@ class RequestRouter
       else
         message = ''
       end
-
       @app.serve_html('coffee/index.html', message: message)
 
     when '/coffee/ready'
-      status_code, message = @app.can_access?('coffee_ready')
-      if status_code == 200
-        status_code, status_message = @app.post_to_google_chat("Ready message triggered! (via Ruby script)")
-        [302, { 'location' => '/coffee?status=ready' }, []]
-      else
-        @app.serve_html('coffee/index.html', message: message)
-      end
+      @app.apply_rate_limit!('coffee_ready')
+      status_code, status_message = @app.post_to_google_chat("Ready message triggered! (via Ruby script)")
+      [302, { 'location' => '/coffee?status=ready' }, []]
 
     when '/coffee/finish'
-      status_code, message = @app.can_access?('coffee_finish')
-      if status_code == 200
-        status_code, status_message = @app.post_to_google_chat("Finish message triggered! (via Ruby script)")
-        [302, { 'location' => '/coffee?status=finish' }, []]
-      else
-        @app.serve_html('coffee/index.html', message: message)
-      end
+      @app.apply_rate_limit!('coffee_finish')
+      status_code, status_message = @app.post_to_google_chat("Finish message triggered! (via Ruby script)")
+      [302, { 'location' => '/coffee?status=finish' }, []]
+
     else
       @app.serve_html('404.html', 404)
     end
+
   end
 end


### PR DESCRIPTION
Implement rate limiting to control the frequency of chat notifications and reduce the risk of abuse. This can involve setting limits on the number of notifications sent per user or IP address within a specific time frame.

I tried to make the route definition minimal as much as I can.